### PR TITLE
Add cops for trailing commas

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -12,3 +12,12 @@ Style/DoubleNegation:
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: consistent_comma


### PR DESCRIPTION
This commit adds 3 tightly-related cops to manage trailing commas in
lists (of method arguments and literals items).

* [Style/TrailingCommaInArguments](https://rubocop.readthedocs.io/en/latest/cops_style/#styletrailingcommainarguments):

    ```ruby
    # bad
    method(1, 2,)

    # good
    method(
      1, 2,
      3,
    )

    # good
    method(
      1,
      2,
    )
    ```

* [Style/TrailingCommaInArrayLiteral](https://rubocop.readthedocs.io/en/latest/cops_style/#styletrailingcommainarrayliteral):

    ```ruby
    # bad
    a = [1, 2,]

    # good
    a = [
      1, 2,
      3,
    ]

    # good
    a = [
      1,
      2,
    ]
    ```

* [Style/TrailingCommaInHashLiteral](https://rubocop.readthedocs.io/en/latest/cops_style/#styletrailingcommainhashliteral):

    ```ruby
    # bad
    a = { foo: 1, bar: 2, }

    # good
    a = {
      foo: 1, bar: 2,
      qux: 3,
    }

    # good
    a = {
      foo: 1,
      bar: 2,
    }
    ```