### PR TITLE
Disable cop Style/AndOr

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,9 @@ Layout/EndAlignment:
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
 
+Style/AndOr:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
This cop "Style/AndOr "ask to replace `and` by `&&`, but we like to use `and` as an action, not condition

```ruby
  action and get :index
  #
  action and return 
```
That's why I submit to disable it.