### PR TITLE
Enforce fixed indentation for parameters

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,9 @@ Layout/AccessModifierIndentation:
 Layout/EndAlignment:
   EnforcedStyleAlignWith: start_of_line
 
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
 Metrics:
   Exclude:
     - spec/**/*.rb


### PR DESCRIPTION
```ruby
# bad
my_method :first_param,
          :second_param

# good
my_method :first_param,
  :second_param
```