### PR TITLE
Disable cop that forces empty line after guard clauses

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,9 @@ Layout/AccessModifierIndentation:
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
 Layout/EmptyLineAfterMagicComment:
   Enabled: false
 


### PR DESCRIPTION
```ruby
# allowed (was bad, before this PR)
def foo
  return if need_return?
  bar
end

# also allowed (but ugly, was enforced before this PR)
def foo
  return if need_return?

  bar
end
```
