### PR TITLE
Disable cop that enforces blank line after magic comment

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -4,6 +4,9 @@ Layout/AccessModifierIndentation:
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+
 Layout/EndAlignment:
   EnforcedStyleAlignWith: start_of_line
 


### PR DESCRIPTION
Now allowed (was bad before this commit):

```ruby
# frozen_string_literal: true
class Person
  # Some code
end
```

Also allowed (was enforced before this commit):

```ruby
# frozen_string_literal: true

class Person
  # Some code
end
```