### PR TITLE
Cleanup default.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,10 +1,10 @@
+# Configuration
+
 inherit_mode:
   merge:
     - Exclude
 
-AllCops:
-  Exclude:
-    - node_modules/**/*
+# Cops
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent


### PR DESCRIPTION
This commit makes it hopefully more readable by:

* separating configuration directives from cops using comments
* removing the exclude of `node_modules', which is actually the default behaviour: https://github.com/alpinelab/codestyle/blob/master/config/default.yml#L1-L3