### PR TITLE
Disable Metrics/BlockLength on specific repositories

### DIFF
--- a/config/rails.yml
+++ b/config/rails.yml
@@ -13,3 +13,5 @@ AllCops:
 Metrics/BlockLength:
   Exclude:
     - config/routes.rb
+    - app/serializers/*
+    - lib/tasks/*

--- a/config/rails.yml
+++ b/config/rails.yml
@@ -15,3 +15,4 @@ Metrics/BlockLength:
     - config/routes.rb
     - app/serializers/*
     - lib/tasks/*
+    - spec/**/*.rb


### PR DESCRIPTION
**Proposition:** I think that cop `Metrics/BlockLength` should be disabled for these repositories:
- `spec/` : not only spec/**/*.rb ,
- `serializers/` : one line per CSV make this rule to constraignant
- `tasks/` : Some tasks can be nested in one block, * 25 lines is not enough in this case.