### PR TITLE
 Modify cop Style/ClassAndModuleChildren

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -46,6 +46,9 @@ Metrics/ModuleLength:
 Style/AndOr:
   Enabled: false
 
+Style/ClassAndModuleChildren:
+  Enabled: false
+
 Style/Documentation:
   Enabled: false
 


### PR DESCRIPTION
EnforcedStyle: **nested** (default)
```ruby
# good
# have each child on its own line
class Foo
  class Bar
  end
end
```
EnforcedStyle: **compact**
```ruby
# good
# combine definitions as much as possible
class Foo::Bar
end
```

Because we don't want to enforce one or the other, purpose of this PR is to disable cop `Style/ClassAndModuleChildren`:

```ruby
# good
class Foo::Bar
end

class Foo
  class Bar
  end
end
```